### PR TITLE
Use absolute path in --volume arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Docker Hub repository can be found [here](https://hub.docker.com/r/brandone2
 
 ```
 docker run \
-    --volume ~/YOUR/PATH/TO/lila:/home/lichess/projects/lila \
+    --volume /YOUR/ABSOLUTE/PATH/TO/lila:/home/lichess/projects/lila \
     --publish 80:80 \
     --publish 9663:9663 \
     --name lichess \


### PR DESCRIPTION
According to [1]:

`--volume` requires an absolute path for the host path.

[1]: https://docs.docker.com/engine/reference/run/#volume-shared-filesystems